### PR TITLE
Handle returned errors properly

### DIFF
--- a/includes/class-trustedlogin-sitekey-login.php
+++ b/includes/class-trustedlogin-sitekey-login.php
@@ -177,7 +177,7 @@ class SiteKey_Login {
 
 		$site_ids = $endpoint->api_get_secret_ids( $access_key );
 
-		if ( is_wp_error( $endpoint ) ){
+		if ( is_wp_error( $site_ids ) ){
 			add_action( 'admin_notices', function () use ( $site_ids ) {
 				echo '<div class="error"><h3>' . esc_html__( 'Could not log in to site using access key.', 'trustedlogin-vendor' ) . '</h3>' . wpautop( esc_html( $site_ids->get_error_message() ) ) . '</div>';
 			} );


### PR DESCRIPTION
Fixes fatal error 

 Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /sites/trustedlogin.dev/files/wp-content/plugins/trustedlogin-vendor/includes/class-trustedlogin-sitekey-login.php:201 Stack trace: #0 /sites/trustedlogin.dev/files/wp-includes/class-wp-hook.php(292): TrustedLogin\Vendor\SiteKey_Login->maybe_handle_accesskey() #1 /sites/trustedlogin.dev/files/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters() #2 /sites/trustedlogin.dev/files/wp-includes/plugin.php(484): WP_Hook->do_action() #3 /sites/trustedlogin.dev/files/wp-admin/admin.php(175): do_action() #4 {main} thrown in /sites/trustedlogin.dev/files/wp-content/plugins/trustedlogin-vendor/includes/class-trustedlogin-sitekey-login.php on line 201