### PR TITLE
Add local test runner for tests , as well as local dev and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,22 @@ The repo lacks the `/vendor/` directory; you'll need to build first. Here's how:
 1. Change directories to the plugin directory (`cd /path/to/directory`)
 1. Run `composer install` - this will also install the code standards directory
 1. Run `./vendor/bin/phpcs`
+
+## Local Development Environment
+
+A [docker-compose](https://docs.docker.com/samples/wordpress/)-based local development environment is provided.
+
+- Start server
+    - `docker-compose up -d`
+- Acess Site
+    - [http://localhost:6300](http://localhost:6100)
+- Run WP CLI command:
+    - `docker-compose run wpcli wp user create admin admin@example.com --role=admin user_pass=pass`
+
+
+There is a special phpunit container for running WordPress tests, with WordPress and MySQL configured.
+
+- Enter container
+    - `docker-compose run phpunit`
+- Test
+    - `phpunit`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3.9"
+
+services:
+
+  wordpress:
+    depends_on:
+      - wpdb
+    image: wordpress:latest
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./:/var/www/html/wp-content/plugins/trustedlogin-vendor
+    ports:
+      - "6300:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: wpdb:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+
+  wpdb:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: wordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wpcli:
+    image: wordpress:cli
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./:/var/www/html/wp-content/plugins/trustedlogin-vendor
+      - ./db:/var/www/html/db
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      ABSPATH: /usr/src/wordpress/
+
+  phpunit:
+    command:
+      - bash
+    depends_on:
+      - testwpdb
+    environment:
+      DATABASE_PASSWORD: examplepass
+      DATABASE_HOST: testwpdb
+    image: futureys/phpunit-wordpress-plugin
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./:/plugin
+
+  testwpdb:
+      environment:
+        MYSQL_ROOT_PASSWORD: examplepass
+      image: mysql:5.7
+
+volumes:
+  db_data: {}
+  wordpress_data: {}


### PR DESCRIPTION
This is part of #58 

this PR adds:

- Local dev
- Local test runner for tests
- Documentation for both

