### PR TITLE
put wordpress in tl-dev network

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ A [docker-compose](https://docs.docker.com/samples/wordpress/)-based local devel
 - Acess Site
     - [http://localhost:6300](http://localhost:6100)
 - Run WP CLI command:
-    - `docker-compose run wpcli wp user create admin admin@example.com --role=admin user_pass=pass`
+    - `docker-compose run wp cli wp ...`
+	- `docker-compose run wpcli wp db reset`
 
+
+In the local development container, the constant `DOING_TL_VENDOR_TESTS` is set to true, as is `WP_DEBUG`.
+
+### Running PHPUnit In Docker
 
 There is a special phpunit container for running WordPress tests, with WordPress and MySQL configured.
 
@@ -33,3 +38,23 @@ There is a special phpunit container for running WordPress tests, with WordPress
     - `docker-compose run phpunit`
 - Test
     - `phpunit`
+
+### Server To Server HTTP Requests
+If the ecommerce app is also running in docker-compose, this WordPress and the "web" service of app should be in "tl-dev" network. This allows you to make an HTTP request to the eCommerce app like this:
+
+
+```php
+$r = wp_remote_get('http://web:80',['sslverify' => false]);
+```
+
+If this doesn't work, make sure a "tl-dev" network exists:
+
+```bash
+docker network ls
+```
+
+If it does not, create one:
+
+```bash
+docker network create tl-dev
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - wordpress_data:/var/www/html
       - ./:/var/www/html/wp-content/plugins/trustedlogin-vendor
+
     ports:
       - "6300:80"
     restart: always
@@ -17,6 +18,12 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+      #WORDPRESS_DEBUG: 1
+      WORDPRESS_CONFIG_EXTRA: |
+        define('DOING_TL_VENDOR_TESTS', true );
+    networks:
+        - tl-dev
+        - tl-vendor
 
   wpdb:
     image: mysql:5.7
@@ -28,6 +35,8 @@ services:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
+    networks:
+        - tl-vendor
 
   wpcli:
     image: wordpress:cli
@@ -41,6 +50,9 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       ABSPATH: /usr/src/wordpress/
+      WORDPRESS_DEBUG: 1
+    networks:
+        - tl-vendor
 
   phpunit:
     command:
@@ -55,12 +67,22 @@ services:
     tty: true
     volumes:
       - ./:/plugin
+    networks:
+        - tl-vendor
 
   testwpdb:
       environment:
         MYSQL_ROOT_PASSWORD: examplepass
       image: mysql:5.7
+      networks:
+        - tl-vendor
 
 volumes:
   db_data: {}
   wordpress_data: {}
+
+
+networks:
+  tl-dev:
+      external: true
+  tl-vendor: {}


### PR DESCRIPTION
Fixes  #69

This PR:

- Puts WordPress in a network that can access the ecommerce app.
- Updates Readme